### PR TITLE
Add partial item search and CI for pytest

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,23 @@
+name: Run tests
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+      - name: Run tests
+        run: pytest tests


### PR DESCRIPTION
## Summary
- add a CLI entry point that resolves items via case-insensitive partial matches and reports ambiguous queries
- cover the new selection behaviour and CLI workflow with tests
- run the pytest suite on pull requests to the master branch via GitHub Actions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da9327717883249f14a64111b3719e